### PR TITLE
Exclude direct Synset-word mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,13 @@ Note: currently when the term-image pairs are built a random image is picked fro
 Options that can be passed to the pair creation script: 
 ```
 python src/create_pairs.py
---image_path #REQUIRED path to the images
---terms_path #path to a file with scored related terms
---difficulty #a score between 0-1 for relatedness between term and image
---frequency #frequency of word in copora, score between 0-8
---num_synsets #how many synsets for the pairs
---per_synset #how many pairs per synset
+--image_path <path> #REQUIRED path to the images
+--terms_path <path> #path to a file with scored related terms
+--difficulty <float> #a score between 0-1 for relatedness between term and image
+--frequency <float> #frequency of word in copora, score between 0-8
+--num_synsets <int> #how many synsets for the pairs
+--per_synset <int> #how many pairs per synset
+--exclude_direct_mapping #exclude the direct Synset-word mapping terms
 ```
 
 #### Relatedness scoring, word frequency and term sources

--- a/src/create_pairs.py
+++ b/src/create_pairs.py
@@ -298,7 +298,7 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--frequency",
-        type=int,
+        type=float,
         help="Frequency threshold",
         required=False,
     )

--- a/src/create_pairs.py
+++ b/src/create_pairs.py
@@ -195,6 +195,19 @@ def _reduce_per_synset(pairs: list):
     return reduced_terms
 
 
+def _exclude_direct_mapping(pairs: list):
+    """
+    This function excludes the direct mapping of the Synset to word terms. Those
+    are all the terms that have scoring of 1 for relatedness.
+    """
+    reduced_terms = []
+    for syn in pairs:
+        terms = [term for s, term in syn.items() if term[0][1] != 1]
+        if terms:
+            reduced_terms.append({list(syn.keys())[0]: terms[0]})
+    return reduced_terms
+
+
 def _create_final_pairs_file(pairs: list):
     """
     This function writes to a .tsv file with the final version of the pairs to be
@@ -239,6 +252,8 @@ def create_pairs(args: argparse.Namespace):
     temp_pairs = possible_pairs
     if args.difficulty:
         temp_pairs = _reduce_by_difficulty(temp_pairs)
+    elif args.exclude_direct_mapping:
+        temp_pairs = _exclude_direct_mapping(temp_pairs)
     elif args.per_synset:
         temp_pairs = _reduce_per_synset(temp_pairs)
     elif args.num_synsets:
@@ -285,6 +300,12 @@ if __name__ == "__main__":
         "--frequency",
         type=int,
         help="Frequency threshold",
+        required=False,
+    )
+    parser.add_argument(
+        "--exclude_direct_mapping",
+        action=argparse.BooleanOptionalAction,
+        help="Exclude direct Synset-word mapping terms",
         required=False,
     )
     args = parser.parse_args()


### PR DESCRIPTION
This PR introduces an option -`-exclude_direct_mapping` to remove the simplest, easiest image-term pairs from the selection. 